### PR TITLE
#28453 : check if value save is a numeric or not, if not display error

### DIFF
--- a/ps_brandlist.php
+++ b/ps_brandlist.php
@@ -87,9 +87,15 @@ class Ps_Brandlist extends Module implements WidgetInterface
 
         if (Tools::isSubmit('submitBlockBrands')) {
             $type = Tools::getValue('BRAND_DISPLAY_TYPE');
-            $text_nb = (int)Tools::getValue('BRAND_DISPLAY_TEXT_NB');
-
-            if ('brand_text' === $type && !Validate::isUnsignedInt($text_nb)) {
+            $text_nb = Tools::getValue('BRAND_DISPLAY_TEXT_NB');
+    
+            if (!is_numeric(Tools::getValue('BRAND_DISPLAY_TEXT_NB'))) {
+                $errors[] = $this->trans(
+                    'Please use only numeric value.',
+                    array(),
+                    'Modules.Brandlist.Admin'
+                );
+            } elseif ('brand_text' === $type && !Validate::isUnsignedInt($text_nb)) {
                 $errors[] = $this->trans(
                     'There is an invalid number of elements.',
                     array(),
@@ -103,7 +109,7 @@ class Ps_Brandlist extends Module implements WidgetInterface
                 );
             } else {
                 Configuration::updateValue('BRAND_DISPLAY_TYPE', $type);
-                Configuration::updateValue('BRAND_DISPLAY_TEXT_NB', $text_nb);
+                Configuration::updateValue('BRAND_DISPLAY_TEXT_NB', (int)$text_nb);
                 $this->_clearCache('*');
             }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Test value if is numeric or not, if not display error and don't save value
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28453.
| How to test?  | - Go to Module catalog<br>- Install module "Brand list"<br>- Go to the configuration of the module<br>- In the field "Number of elements to display" input random characters<br>- Press "Save"

Note: before this pr, you could write `5TOTO` and it would work, because it would be cast as an integer, giving `5`, with this fix you get an error because the value is not correct, which is the right behavior IMHO (matthieu-rolland)

