### PR TITLE
Allow only integers for the configuration 'Number of elements to display'

### DIFF
--- a/ps_brandlist.php
+++ b/ps_brandlist.php
@@ -87,7 +87,7 @@ class Ps_Brandlist extends Module implements WidgetInterface
 
         if (Tools::isSubmit('submitBlockBrands')) {
             $type = Tools::getValue('BRAND_DISPLAY_TYPE');
-            $text_nb = (int) Tools::getValue('BRAND_DISPLAY_TEXT_NB');
+            $text_nb = Tools::getValue('BRAND_DISPLAY_TEXT_NB');
 
             $errors = [];
             if ('brand_text' === $type && !Validate::isUnsignedInt($text_nb)) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Allow only integers for the configuration 'Number of elements to display'
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28453
| How to test?  | Cf. PrestaShop/Prestashop#28453

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
