### PR TITLE
 Does not load content if PS_DISPLAY_MANUFACTURERS is set to false

### DIFF
--- a/ps_brandlist.php
+++ b/ps_brandlist.php
@@ -258,6 +258,10 @@ class Ps_Brandlist extends Module implements WidgetInterface
         $hookName = null,
         array $configuration = array()
     ) {
+        if (!Configuration::get('PS_DISPLAY_MANUFACTURERS')) {
+            return;
+        }
+
         $cacheId = $this->getCacheId('ps_brandlist');
         $isCached = $this->isCached($this->templateFile, $cacheId);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | If the PS_DISPLAY_MANUFACTURERS is set to false, every link to the manufacturer page will redirect into a 404 page. There is no need to list them with links if the visitor could not see the manufacturer page.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | See that manufacturers list is not anymore into the left column.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
