### PR TITLE
Check if manufacturers are enabled

### DIFF
--- a/ps_brandlist.php
+++ b/ps_brandlist.php
@@ -259,6 +259,12 @@ class Ps_Brandlist extends Module implements WidgetInterface
         $hookName = null,
         array $configuration = []
     ) {
+        // If manufacturer listing is disabled in backoffice, we won't show this block.
+        // Customers would be pointed to 404 anyway.
+        if (!Configuration::get('PS_DISPLAY_MANUFACTURERS')) {
+            return;
+        }
+
         $cacheId = $this->getCacheId('ps_brandlist');
         $isCached = $this->isCached($this->templateFile, $cacheId);
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Check if manufacturers are enabled when rendering the block.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#33361
| How to test?  | Check that this module is hooked and displayed somewhere. Disable manufacturers in BO > Shop settings > General. See that this module disappears from FO.