### PR TITLE
Fix condition for manufacturers

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
     <name>ps_brandlist</name>
     <displayName><![CDATA[Brand list]]></displayName>
-    <version><![CDATA[1.0.4]]></version>
+    <version><![CDATA[1.0.5]]></version>
     <description><![CDATA[Displays a block listing product brands.]]></description>
     <author><![CDATA[PrestaShop]]></author>
     <tab><![CDATA[front_office_features]]></tab>

--- a/ps_brandlist.php
+++ b/ps_brandlist.php
@@ -38,7 +38,7 @@ class Ps_Brandlist extends Module implements WidgetInterface
     {
         $this->name = 'ps_brandlist';
         $this->tab = 'front_office_features';
-        $this->version = '1.0.4';
+        $this->version = '1.0.5';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -259,9 +259,16 @@ class Ps_Brandlist extends Module implements WidgetInterface
         $hookName = null,
         array $configuration = []
     ) {
-        // If manufacturer listing is disabled in backoffice, we won't show this block.
-        // Customers would be pointed to 404 anyway.
-        if (!Configuration::get('PS_DISPLAY_MANUFACTURERS')) {
+        /*
+         * If manufacturer listing is disabled in backoffice, we won't show this block.
+         * Customers would be pointed to 404 anyway.
+         *
+         * We need to check different configuration keys depending on PrestaShop versions,
+         * it changed in https://github.com/PrestaShop/PrestaShop/pull/14665 to allow
+         * independent control of manufacturers and suppliers. before, there was only
+         * PS_DISPLAY_SUPPLIERS for both.
+         */
+        if (!Configuration::get(version_compare(_PS_VERSION_, '1.7.7.0', '>=') ? 'PS_DISPLAY_MANUFACTURERS' : 'PS_DISPLAY_SUPPLIERS')) {
             return;
         }
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This block won't be displayed on 1.7.0 - 1.7.6. Why? We added a condition that respects the "Display manufacturers" switch in backoffice, but this switch was introduced in 1.7.7. Before that, it was controlled by "Enable suppliers" switch. This fixes it and respects the proper option on all versions.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See below

Test 1
- Install 1.7.6
- See that the block is correctly controlled by the **Display suppliers** switch in settings
- (That's how it was before.)

Test 2
- Install 1.7.7
- See that you have these independent switches now.
- See that the block is correctly controller by the **Display brands** switch.